### PR TITLE
os.environ must be copied, Crucial bug! Very important!

### DIFF
--- a/tiny-matrix-bot.py
+++ b/tiny-matrix-bot.py
@@ -81,7 +81,7 @@ class TinyMatrixtBot():
                     not os.access(script_path, os.X_OK)):
                 logger.debug("script {} is not executable".format(script_name))
                 continue
-            script_env = os.environ
+            script_env = os.environ.copy()
             script_env["CONFIG"] = "1"
             logger.debug("script {} config with env {}".format(script_name, script_env))
             script_regex = subprocess.Popen(


### PR DESCRIPTION
This is a serious bug. If no copy is made all variables defined in the config file will share the same memory and will be overwritten!

For example: you have the function ping and pong in the config file. Both set the variable "reply". Say, ping sets the reply to "PONG" and pong sets the reply to "PING". Since without copy the share the same memory, both reply-variables actually point to the SAME memory and value. So first it is set to PONG. Then it is set to PING but now BOTH functions ping and pong have the parameter reply set to "PING". 

The same goes for the whitelists and blacklists, the last one always overwrites all previous occurrences.Hence it is absolutely crucial to make a copy of that list! So that each function has a SEPARATE copy and no overwriting takes place.

And by the way, nice code! Thank you for sharing!