### PR TITLE
firewall: bot command to show state of server firewall

### DIFF
--- a/scripts/firewall
+++ b/scripts/firewall
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+if [ -n "$CONFIG" ]; then
+        echo '^firewall$|^fw$|^!?firewall.*$'
+        exit 0
+fi
+
+# ufw must be installed
+type ufw >/dev/null 2>&1 || {
+        echo "This script requires that you install the packge \"ufw\" on the server to check your firewall."
+        exit 0
+}
+
+fi=$(sudo ufw status verbose)
+bold=$(tput bold)
+red=$(tput setaf 1)
+yellow=$(tput setaf 3)
+green=$(tput setaf 2)
+reset=$(tput sgr0)
+fi=${fi//deny/${green}${bold}deny${reset}}
+fi=${fi//reject/${yellow}${bold}reject${reset}}
+fi=${fi//allow/${red}${bold}allow${reset}}
+fi=${fi//disabled/${green}${bold}disabled${reset}}
+fi=${fi//enabled/${red}${bold}enabled${reset}}
+echo -e -n "$fi"
+echo
+
+# Argument __reply from config file is not used in this script
+#if [ -n "$__reply" ]
+#then
+#    echo "$__reply"
+#else
+#    echo 'P O N G'
+#fi


### PR DESCRIPTION
- lists details of firewall configuration
- ports opened, etc.
- for use by a system admin
- allows user with permission to check up on firewall
- set permissions correctly in config file tiny-matrix-bot.cfg (whitelist, blacklist, etc)
- allows user with permission to monitor server running Matrix via the bot
- requires ufw to be installed, checks ufw status