### PR TITLE
totp: bot command to return TOTP PIN for 2FA

### DIFF
--- a/scripts/totp
+++ b/scripts/totp
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+if [ -n "$CONFIG" ]; then
+        echo '^otp$|^totp$|^otp .*$|^totp .*$'
+        exit 0
+fi
+
+# Example URI:
+# otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example
+
+# Example TOTP secret key:
+# JBSWY3DPEHPK3PXP
+
+# TOTP secret can be password protected thru a 2nd argument
+
+# Do this to encypt a TOTP secret key:
+# echo "JBSWY3DPEHPK3PXP" | openssl enc -aes-256-cbc -salt -a -pbkdf2 # returns encrypted TOTP key
+# "U2FsdGVkX1+etVuH68uNDv1v5J+XfYXRSuuEyypLJrEGCfo4V91eICW1085lQa68" # TOTP secret key "JBSWY3DPEHPK3PXP" encrypted with passphrase "test"
+
+# the reverse is: decrypted the cipher text to get original TOTP secret key, in the example we use passphrase "test"
+# echo "U2FsdGVkX1+etVuH68uNDv1v5J+XfYXRSuuEyypLJrEGCfo4V91eICW1085lQa68"  | openssl enc -aes-256-cbc -d -salt -a -pbkdf2 -k test # returns "JBSWY3DPEHPK3PXP"
+# JBSWY3DPEHPK3PXP
+
+# oathtool must be installed
+type oathtool >/dev/null 2>&1 || {
+        echo "This script requires that you install the packge \"oathtool\" on the server."
+        exit 0
+}
+
+function totp() {
+        D="$(date +%S)"
+        # shellcheck disable=SC2001
+        DNOLEADINGZERO=$(echo "$D" | sed 's/^0//')
+        # shellcheck disable=SC2004
+        SECONDSREMAINING=$((30 - $DNOLEADINGZERO % 30))
+        X=$(oathtool --totp -b "$TOKEN")
+        echo "$SECONDSREMAINING seconds remaining : $X"
+}
+
+arg1=$(echo "$1" | tr -s ' ' | cut -s -d ' ' -f 2)
+arg2=$(echo "$1" | tr -s ' ' | cut -s -d ' ' -f 3)
+#echo "totp: arguments : \"$1\""
+#echo "totp: argument 1: \"$arg1\"" # totp-nick-name
+#echo "totp: argument 2: \"$arg2\"" # optional password
+if [ "$arg1" == "" ]; then
+        echo "No TOTP nick-name given. Try \"totp example-plaintext\" or \"totp example-encrypted\" next time."
+        echo "This script has to be set up on the server to be meaningful."
+        echo "As shipped it only has an example of a TOTP  service."
+        exit 0
+fi
+case "$arg1" in
+example-plaintext)
+        # echo "Calculating TOTP PIN for you"
+        PLAINTEXTTOTPKEY="JBSWY3DPEHPK3PXP"
+        totp "$PLAINTEXTTOTPKEY"
+        exit 0
+        ;;
+example-encrypted)
+        # echo "Calculating TOTP PIN for you"
+        if [ "$arg2" == "" ]; then
+                echo "A password is required for this TOTP nick name."
+                exit 0
+        fi
+        CIPHERTOTPKEY="U2FsdGVkX1+etVuH68uNDv1v5J+XfYXRSuuEyypLJrEGCfo4V91eICW1085lQa68"
+        PLAINTEXTTOTPKEY=$(echo "$CIPHERTOTPKEY" | openssl enc -aes-256-cbc -d -salt -a -pbkdf2 -k "$arg2")
+        totp "$PLAINTEXTTOTPKEY"
+        # echo "Using \"$arg2\" as password. Totp secret is \"$TOTPSECRET\"."
+        exit 0
+        ;;
+*)
+        echo "Unknown TOTP nick name \"$arg1\". Not configured on server."
+        ;;
+esac
+
+#if [ -n "$__reply" ]
+#then
+#    echo "$__reply"
+#else
+#    echo 'P O N G'
+#fi


### PR DESCRIPTION
- can be set uo work in plain text 
- can be set up to work encrypted with password
- know about the security trade-offs of putting 2FA (Two Factor Authentication) on a chat bot
- not intended for massive public bot
- use case might be a small private homeserver for John Doe and his 3 friends
- give it a TOTP nickname and an optional password and it will send you back your 2FA TOTP PIN
- for set-up see source code of script
- for use by a system admin or friends
- set permissions correctly in config file tiny-matrix-bot.cfg (whitelist, blacklist, etc)
- requires oathtool to be installed