### PR TITLE
add optional proxy feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Optional environment variables with defaults:
 
 If it's required to connect the homeserver through a simple proxy:
 
-* `TMB_PROXY` = `http://squid.internal:3128`
+* `TMB_PROXY` = `http://proxy.example.com:3128`
 
 ## Scripts
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Optional environment variables with defaults:
 * `TMB_SCRIPTS_PATH` = `scripts-enabled`
 * `TMB_ACCEPT_INVITES` = `:example\.com$` (derived from `TMB_USER_ID` when unset)
 
+If it's required to connect the homeserver through a simple proxy:
+
+* `TMB_PROXY` = `http://squid.internal:3128`
+
 ## Scripts
 
 Scripts can be written in any language and they MUST have `+x` bit set.

--- a/tiny-matrix-bot.env.sample
+++ b/tiny-matrix-bot.env.sample
@@ -1,4 +1,3 @@
 TMB_HOMESERVER="https://example.com"
 TMB_ACCESS_TOKEN="ABCDEFGH"
 TMB_USER_ID="@bot:example.com"
-#TMB_PROXY="http://proxy.example.com:3128"

--- a/tiny-matrix-bot.env.sample
+++ b/tiny-matrix-bot.env.sample
@@ -1,4 +1,4 @@
 TMB_HOMESERVER="https://example.com"
 TMB_ACCESS_TOKEN="ABCDEFGH"
 TMB_USER_ID="@bot:example.com"
-#TMB_PROXY="http://squid.internal:3128"
+#TMB_PROXY="http://proxy.example.com:3128"

--- a/tiny-matrix-bot.env.sample
+++ b/tiny-matrix-bot.env.sample
@@ -1,3 +1,4 @@
 TMB_HOMESERVER="https://example.com"
 TMB_ACCESS_TOKEN="ABCDEFGH"
 TMB_USER_ID="@bot:example.com"
+#TMB_PROXY="http://squid.internal:3128"

--- a/tiny-matrix-bot.py
+++ b/tiny-matrix-bot.py
@@ -22,6 +22,7 @@ class TinyMatrixBot:
     user_id = None
     accept_invites = None
     scripts_path = None
+    proxy = None
     _scripts = None
 
     def __init__(self):

--- a/tiny-matrix-bot.py
+++ b/tiny-matrix-bot.py
@@ -96,7 +96,7 @@ class TinyMatrixBot:
         if self.proxy is None:
             self._client = nio.AsyncClient(self.homeserver)
         else:
-            self._client = nio.AsyncClient(self.homeserver,proxy=self.proxy)
+            self._client = nio.AsyncClient(self.homeserver, proxy=self.proxy)
         self._client.access_token = self.access_token
         self._client.user_id = self.user_id
         self._client.device_id = 'TinyMatrixBot'

--- a/tiny-matrix-bot.py
+++ b/tiny-matrix-bot.py
@@ -22,7 +22,6 @@ class TinyMatrixBot:
     user_id = None
     accept_invites = None
     scripts_path = None
-    proxy = None
     _scripts = None
 
     def __init__(self):
@@ -93,10 +92,7 @@ class TinyMatrixBot:
 
     async def run(self):
         print(f'connecting to {self.homeserver}')
-        if self.proxy is None:
-            self._client = nio.AsyncClient(self.homeserver)
-        else:
-            self._client = nio.AsyncClient(self.homeserver, proxy=self.proxy)
+        self._client = nio.AsyncClient(self.homeserver, proxy=self.proxy)
         self._client.access_token = self.access_token
         self._client.user_id = self.user_id
         self._client.device_id = 'TinyMatrixBot'

--- a/tiny-matrix-bot.py
+++ b/tiny-matrix-bot.py
@@ -22,6 +22,7 @@ class TinyMatrixBot:
     user_id = None
     accept_invites = None
     scripts_path = None
+    proxy = None
     _scripts = None
 
     def __init__(self):
@@ -92,7 +93,10 @@ class TinyMatrixBot:
 
     async def run(self):
         print(f'connecting to {self.homeserver}')
-        self._client = nio.AsyncClient(self.homeserver)
+        if self.proxy is None:
+            self._client = nio.AsyncClient(self.homeserver)
+        else:
+            self._client = nio.AsyncClient(self.homeserver,proxy=self.proxy)
         self._client.access_token = self.access_token
         self._client.user_id = self.user_id
         self._client.device_id = 'TinyMatrixBot'


### PR DESCRIPTION
Missing the possibility to connect the homeserver through a simple proxy. The old SDK evaluates the https_proxy environment. It may be the better and more transparent method to use https_proxy insteed of my proposal (TMB_PROXY)